### PR TITLE
Add outbound 53/udp rule to the lambdas security group to authorize D…

### DIFF
--- a/dist/multi-region-cft/CyberArk-AOB-MultiRegion-CF.json
+++ b/dist/multi-region-cft/CyberArk-AOB-MultiRegion-CF.json
@@ -919,6 +919,18 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "EgressAccessDNS": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "ElasticityLambdaSecurityGroup"
+        },
+        "IpProtocol": "udp",
+        "FromPort": "53",
+        "ToPort": "53",
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
     "LambdaS3BucketRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {


### PR DESCRIPTION
…NS resolution.

Adding the 53/udp rule allow the lambdas to perform DNS resolution, thus
allowing to use a PVWA domain name instead of an IP address.